### PR TITLE
fathom tprobe.h: Removed uint8_t bool on line 53 to fix newer gcc issue

### DIFF
--- a/src/fathom/tbprobe.h
+++ b/src/fathom/tbprobe.h
@@ -50,7 +50,6 @@ typedef long long int64_t;
 #include <stdbool.h>
 #else
 #ifndef __cplusplus
-typedef uint8_t bool;
 #define true    1
 #define false   0
 #endif


### PR DESCRIPTION
This fixes the
```bash
fathom/tbprobe.h:53:17: error: two or more data types in declaration specifiers
   53 | typedef uint8_t bool;
      |                 ^~~~
```
issues on rolling linux systems